### PR TITLE
BC Callback: request, response, ...args

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ It's recommended that you use Composer to install Mark.
 # Usage
 start.php
 ```php
+
 <?php
 use Mark\App;
 
@@ -17,16 +18,16 @@ $api = new App('http://0.0.0.0:3000');
 
 $api->count = 4; // process count
 
-$api->any('/', function ($requst) {
-    return 'Hello world';
+$api->any('/', function ($request, $response) {
+    return $response->withBody('Hello world');
 });
 
-$api->get('/hello/{name}', function ($requst, $name) {
-    return "Hello $name";
+$api->get('/hello/{name}', function ($request, $response, $name) {
+    return $response->withBody("Hello $name");
 });
 
-$api->post('/user/create', function ($requst) {
-    return json_encode(['code'=>0 ,'message' => 'ok']);
+$api->post('/user/create', function ($request, $response) {
+    return $response->withBody(json_encode(['code' => 0, 'message' => 'ok']));
 });
 
 $api->start();


### PR DESCRIPTION
# Breaking changes

Closes #13 

Useful for headers, status code and other purposes.
`$response` is an instance of `\Workerman\Protocols\Http\Response`

Example of JSON endpoint:
```
$api->get('/json', function ($request, $response) {
    return $response->withHeader('Content-Type', 'application/json')
                    ->withBody(json_encode(['a' => 1, 'b' => 2]));
});
```

# Breaking changes