### PR TITLE
Added support of nested groups for routing

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -114,9 +114,10 @@ class App extends Worker
      */
     public function group($path, $callback)
     {
-        $this->pathPrefix = $path;
+        $oldPrefix = $this->pathPrefix;
+        $this->pathPrefix .= $path;
         $callback($this);
-        $this->pathPrefix = '';
+        $this->pathPrefix = $oldPrefix;
     }
 
     /**


### PR DESCRIPTION
You can now safely create nested route groups

```
$api->group('/1', function ($api) {
    $api->get('/1', function () {
        return '1';
    });

    $api->group('/2', function ($api) {
        $api->get('/2', function () {
            return '2';
        });
    });
});
```