### PR TITLE
Use also Workerman v5.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "description": "a PHP API micro framework based on workerman",
   "require": {
     "php": ">=7.1",
-    "workerman/workerman": "^4.0.4",
+    "workerman/workerman": "^4.0.4|^5.1",
     "nikic/fast-route": "^1.3"
   },
   "suggest": {


### PR DESCRIPTION
It's working with the Techempower benchmark without problems.

![image](https://github.com/user-attachments/assets/3a2f7017-10fa-4f48-9638-fe8a671bb57a)


The only change with Workerman/5 is the change for Timer namespace:
Workerman/4 `use Workerman\Lib\Timer;`
Workerman/5 `use Workerman\Timer;`


Fix #32
